### PR TITLE
chore: replicate locksmith workflow updates

### DIFF
--- a/.github/copilot/mcp.json
+++ b/.github/copilot/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,12 +9,12 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,47 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: copilot-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
+          restore-keys: copilot-go-
+
+      - name: Download Go module dependencies
+        run: |
+          go mod download
+          go mod download -modfile tools/go.mod
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
+
+      - name: Warm up govulncheck
+        run: go tool -modfile tools/go.mod govulncheck -version

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -41,7 +41,7 @@ jobs:
           go mod download -modfile tools/go.mod
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
+        run: make install/tools
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version

--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -42,8 +42,14 @@ jobs:
             gh pr merge --auto -s "$PR_URL"
           fi
 
-      - name: Re-approve after force-update if auto-merge was already configured
-        if: steps.metadata.outcome == 'failure' && github.event.action == 'synchronize'
+      - name: Re-approve after branch update if auto-merge was already configured
+        # Runs on synchronize events where step 4 would be skipped — i.e. when fetch-metadata
+        # either failed (outcome=failure) or returned an empty/unexpected update-type.
+        # The auto-merge check inside the script guards against re-approving major updates.
+        if: >-
+          github.event.action == 'synchronize' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-minor'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GOPATH ?= $(shell go env GOPATH)
+GOBIN ?= $(GOPATH)/bin
+
 validate: static-analysis/lint static-analysis/vulncheck test/unit examples/samplemod/run
 	@echo "Validation successful"
 
@@ -54,4 +57,4 @@ static-analysis/vulncheck-sarif:
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 
 install/tools:
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,7 @@ static-analysis/vulncheck-sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 
-install/tools:
+install-lint:
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+
+install/tools: install-lint

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,5 @@ static-analysis/vulncheck-sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 
-install/tools: install-lint
+install/tools:
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,5 @@ static-analysis/vulncheck-sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 
-install-lint:
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
-
 install/tools: install-lint
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2


### PR DESCRIPTION
## Summary
- replicate the recent Dependabot auto-approve update from `locksmith`
- add or update `copilot-setup-steps.yml` based on `locksmith`
- add `.github/copilot/mcp.json`

## Notes
- `kerberos` keeps its repo-specific Copilot setup extras while adopting the newer workflow pattern