### PR TITLE
ci: fix Go cache checksum generation

### DIFF
--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -26,13 +26,17 @@ jobs:
       - name: Checksum
         id: checksum
         run: |
-          sha256sum go.mod go.sum > modsum.txt
+          checksum=$(
+            {
+              sha256sum go.mod go.sum
 
-          # Exclude _test files, they are not needed to build the code and they change more often than the actual code. 
-          find . -type f -name "*.go" ! -name "*_test.go" -exec sha256sum {} \; > gosum.txt
-          sha256sum modsum.txt gosum.txt > totalmodsum.txt
-          sha256sum totalmodsum.txt > totalmodsum.txt
-          echo "checksum=$(cat totalmodsum.txt | awk '{print $1}')" >> $GITHUB_OUTPUT
+              # Exclude _test files; they are not needed to build the code and
+              # they change more often than the actual build inputs.
+              find . -type f -name "*.go" ! -name "*_test.go" -print0 | \
+                sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
       # Use restore-keys to always use a cache that was created with the same
       # prefix.

--- a/.github/workflows/callable-test-function.yaml
+++ b/.github/workflows/callable-test-function.yaml
@@ -26,13 +26,17 @@ jobs:
       - name: Checksum
         id: checksum
         run: |
-          sha256sum go.mod go.sum > modsum.txt
+          checksum=$(
+            {
+              sha256sum go.mod go.sum
 
-          # Exclude _test files, they are not needed to build the code and they change more often than the actual code. 
-          find . -type f -name "*.go" ! -name "*_test.go" -exec sha256sum {} \; > gosum.txt
-          sha256sum modsum.txt gosum.txt > totalmodsum.txt
-          sha256sum totalmodsum.txt > totalmodsum.txt
-          echo "checksum=$(cat totalmodsum.txt | awk '{print $1}')" >> $GITHUB_OUTPUT
+              # Exclude _test files; they are not needed to build the code and
+              # they change more often than the actual build inputs.
+              find . -type f -name "*.go" ! -name "*_test.go" -print0 | \
+                sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
       # Use restore-keys to always use a cache that was created with the same
       # prefix.

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -26,13 +26,17 @@ jobs:
       - name: Checksum
         id: checksum
         run: |
-          sha256sum go.mod go.sum > modsum.txt
+          checksum=$(
+            {
+              sha256sum go.mod go.sum
 
-          # Exclude _test files, they are not needed to build the code and they change more often than the actual code. 
-          find . -type f -name "*.go" ! -name "*_test.go" -exec sha256sum {} \; > gosum.txt
-          sha256sum modsum.txt gosum.txt > totalmodsum.txt
-          sha256sum totalmodsum.txt > totalmodsum.txt
-          echo "checksum=$(cat totalmodsum.txt | awk '{print $1}')" >> $GITHUB_OUTPUT
+              # Exclude _test files; they are not needed to build the code and
+              # they change more often than the actual build inputs.
+              find . -type f -name "*.go" ! -name "*_test.go" -print0 | \
+                sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
       # Use restore-keys to always use a cache that was created with the same
       # prefix.


### PR DESCRIPTION
## Summary
- replace the custom cache checksum step with a deterministic sha256 pipeline
- sort Go file paths before hashing so the result is stable across runs
- fix the arbiter bug where the workflow hashed `totalmodsum.txt` back into the same file