### PR TITLE
Split Go module and build caches

### DIFF
--- a/.github/skills/arbiter-module-development/SKILL.md
+++ b/.github/skills/arbiter-module-development/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: arbiter-module-development
+description: 'Write Arbiter load-testing modules for an application. Covers the module interface, how to structure Args and Ops, lifecycle hooks, and the concrete samplemod example.'
+argument-hint: 'Optional: the target application or protocol you want the module to exercise'
+---
+
+# Arbiter Module Development
+
+## When to Use
+
+- Writing a new Arbiter module to load test an HTTP API, gRPC service, database-backed app, queue consumer, or any other system under test
+- Refactoring an existing module to expose better Args or Ops
+- Understanding how to implement the `module.Module` interface Arbiter expects
+- Looking for a concrete reference implementation in this repo
+
+---
+
+## Core Interface
+
+An Arbiter module is a Go type that implements `pkg/module.Module`:
+
+```go
+type Module interface {
+    Name() string
+    Desc() string
+    Args() Args
+    Ops() Ops
+    Run() error
+    Stop() error
+}
+```
+
+Use it to describe:
+
+- **module identity** via `Name` and `Desc`
+- **configuration** via `Args`
+- **load-generating operations** via `Ops`
+- **setup/teardown** via `Run` and `Stop`
+
+Register one or more modules from your program's `main`:
+
+```go
+func main() {
+    err := arbiter.Run(module.Modules{mymod.New()}, nil)
+    // handle err
+}
+```
+
+---
+
+## Naming Rules
+
+- `Name()` must be unique and kebab-case / lowercase-alphanumeric-plus-dashes
+- Operation names must follow the same pattern
+- Do not use reserved module names/prefixes like `arbiter` or `reporter`
+
+The runtime validates module and op names before starting.
+
+---
+
+## Recommended Module Shape
+
+Follow the same pattern as `examples/samplemod/module/module.go`:
+
+```go
+type MyModule struct {
+    args module.Args
+    ops  module.Ops
+
+    baseURL string
+    client  *http.Client
+}
+
+func New() module.Module {
+    m := &MyModule{
+        client: &http.Client{},
+    }
+
+    m.args = module.Args{
+        &module.Arg[string]{
+            Name:     "base-url",
+            Desc:     "Base URL of the target service.",
+            Required: true,
+            Value:    &m.baseURL,
+        },
+    }
+
+    m.ops = module.Ops{
+        &module.Op{
+            Name: "health",
+            Desc: "Calls the health endpoint.",
+            Rate: 60,
+            Do: func() (module.Result, error) {
+                start := time.Now()
+
+                // perform request here
+
+                return module.Result{Duration: time.Since(start)}, nil
+            },
+        },
+    }
+
+    return m
+}
+```
+
+Keep parsed config and reusable clients on the struct; build `Args` and `Ops` once in `New`.
+
+---
+
+## Args: Exposing Module Configuration
+
+`Args()` returns `module.Args`, which is a list of typed arguments Arbiter exposes for the module.
+
+Supported argument types:
+
+- `int`
+- `uint`
+- `float64`
+- `string`
+- `bool`
+
+Use `module.Arg[T]`:
+
+```go
+&module.Arg[string]{
+    Name:     "host",
+    Desc:     "Target host.",
+    Required: true,
+    Value:    &m.host,
+}
+```
+
+### Important fields
+
+| Field | Meaning |
+|---|---|
+| `Name` | Argument name exposed by the module |
+| `Desc` | Help text / description |
+| `Required` | Startup fails if omitted |
+| `Value` | Pointer that receives the parsed value and can also provide a default |
+| `Handler` | Optional callback for derived parsing or conversion |
+| `Valid` | Optional validator for rejecting invalid values |
+
+### When to use `Value` vs `Handler`
+
+- Use **`Value`** when the parsed type is already the form your module wants
+- Use **`Handler`** when you want to derive another field, such as converting milliseconds to `time.Duration`
+- You can use both together
+
+Example:
+
+```go
+&module.Arg[int]{
+    Name: "timeout-ms",
+    Desc: "Request timeout in milliseconds.",
+    Handler: func(v int) {
+        m.timeout = time.Duration(v) * time.Millisecond
+    },
+}
+```
+
+Prefer Args for things that define the workload or target, such as:
+
+- target URL / host / port
+- auth token, username, password, API key source
+- request payload size
+- tenant, topic, queue, table, or endpoint selection
+- timeouts and feature toggles
+
+---
+
+## Ops: Exposing Load-Generating Operations
+
+`Ops()` returns `module.Ops`, a list of `*module.Op`. Each op is one independently scheduled workload.
+
+```go
+&module.Op{
+    Name: "get-user",
+    Desc: "Fetch a user by ID.",
+    Rate: 120,
+    Do: func() (module.Result, error) {
+        start := time.Now()
+
+        // execute one unit of work
+
+        return module.Result{Duration: time.Since(start)}, nil
+    },
+}
+```
+
+### Op fields
+
+| Field | Meaning |
+|---|---|
+| `Name` | Operation name |
+| `Desc` | Description of the operation |
+| `Disabled` | Skip scheduling this op |
+| `Rate` | Target executions **per minute** |
+| `Do` | Function Arbiter calls for one execution |
+
+### Important runtime behavior
+
+- Arbiter schedules each op independently
+- `Rate` is treated as **calls per minute** by the runtime and generated op settings
+- `Rate` must be **greater than zero** for scheduled ops
+- `Disabled: true` prevents the op from being scheduled
+
+Each op also gets its own exposed runtime controls through Arbiter:
+
+- per-op **rate override**
+- per-op **disable switch**
+
+That means you should define stable, meaningful operations like `login`, `search`, `create-order`, or `publish-message`, and let Arbiter manage their pacing.
+
+### What `Do` should return
+
+- Return `module.Result{Duration: ...}` with the time spent doing the operation
+- Return `nil` error on success
+- Return a non-nil error for failed attempts; Arbiter records failures in reporting
+
+Keep one `Do` call to one logical unit of work. If you need a multi-step scenario, either:
+
+- keep the full scenario in a single op, or
+- model separate behaviors as separate ops with their own rates
+
+---
+
+## Lifecycle: `Run` and `Stop`
+
+Use lifecycle hooks for setup and cleanup:
+
+- `Run()` is called once before traffic starts
+- `Stop()` is called once after traffic stops
+
+Good `Run` responsibilities:
+
+- build HTTP/gRPC/database clients
+- warm up auth/session state
+- create reusable fixtures or IDs
+- validate required connectivity early
+
+Good `Stop` responsibilities:
+
+- close clients/connections
+- clean up temporary resources created by the module
+
+Avoid heavy setup inside `Do` unless every invocation really needs it.
+
+---
+
+## Practical Module Design Guidance
+
+When building a module for a real application:
+
+1. Put shared clients, config, and reusable state on the module struct.
+2. Use `Args` for everything that should vary between environments or test runs.
+3. Split `Ops` by user-visible behavior or traffic class, not by tiny implementation detail.
+4. Measure the duration around the actual operation work so Arbiter reports useful timings.
+5. Return real errors instead of swallowing them; Arbiter uses them for failure counts.
+6. Keep operation names stable so reports stay easy to compare over time.
+
+Examples of good op splits:
+
+- API service: `list-products`, `get-product`, `create-cart`, `checkout`
+- Messaging system: `publish`, `consume`, `ack`, `redeliver`
+- Auth service: `login`, `refresh-token`, `introspect-token`
+
+---
+
+## No-Ops Modules
+
+A module with no ops is valid if you want the module to drive traffic itself from `Run()`.
+
+For normal application load testing, prefer defining explicit `Ops` so Arbiter can schedule, report, and tune them independently.
+
+---
+
+## Concrete Example in This Repo
+
+Use `examples/samplemod` as the main reference:
+
+- `examples/samplemod/main.go` shows how the module is registered with `arbiter.Run`
+- `examples/samplemod/module/module.go` shows:
+  - a constructor that builds `args` and `ops`
+  - one required arg and one handler-based arg
+  - multiple operations
+  - success and error-returning `Do` functions
+  - minimal `Run` / `Stop` implementations
+
+That example is the best template to copy when starting a new module in this repository.

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -38,16 +38,35 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
-          restore-keys: build-
+          restore-keys: |
+            build-${{ matrix.go-version-alias }}-
 
       - name: Build sample mod
         run: make examples/samplemod/build
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -38,16 +38,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -56,17 +54,3 @@ jobs:
 
       - name: Build sample mod
         run: make examples/samplemod/build
-
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -40,14 +40,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -59,14 +59,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-function.yaml
+++ b/.github/workflows/callable-test-function.yaml
@@ -38,16 +38,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -56,17 +54,3 @@ jobs:
 
       - name: Run samplemod executable
         run: make examples/samplemod/run
-
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-function.yaml
+++ b/.github/workflows/callable-test-function.yaml
@@ -38,16 +38,35 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
-          restore-keys: function-test-
+          restore-keys: |
+            function-test-${{ matrix.go-version-alias }}-
 
       - name: Run samplemod executable
         run: make examples/samplemod/run
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-function.yaml
+++ b/.github/workflows/callable-test-function.yaml
@@ -40,14 +40,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -59,14 +59,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -38,19 +38,38 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
-          restore-keys: unit-test-
+          restore-keys: |
+            unit-test-${{ matrix.go-version-alias }}-
 
       - name: Run tests
         run: make test/unit-json
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
 
       - name: Publish test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -38,16 +38,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -57,19 +55,6 @@ jobs:
       - name: Run tests
         run: make test/unit-json
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
 
       - name: Publish test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -40,14 +40,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
@@ -59,14 +59,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -54,16 +54,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
@@ -73,19 +71,6 @@ jobs:
       - name: Run govulncheck
         run: make static-analysis/vulncheck-sarif
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload SARIF report
         if: always()

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -56,14 +56,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
@@ -75,14 +75,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -41,10 +41,51 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
-          cache-dependency-path: tools/go.sum
+          cache: false
+
+      - name: Checksum
+        id: checksum
+        run: |
+          checksum=$(
+            {
+              sha256sum tools/go.mod tools/go.sum
+              find . -type f -name "*.go" -print0 | sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
+          restore-keys: |
+            govulncheck-build-
 
       - name: Run govulncheck
         run: make static-analysis/vulncheck-sarif
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload SARIF report
         if: always()

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
@@ -66,14 +66,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,14 +26,32 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Cache Go modules and build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Checksum
+        id: checksum
+        run: |
+          checksum=$(
+            {
+              sha256sum go.mod go.sum tools/go.mod tools/go.sum
+              find . -type f -name "*.go" -print0 | sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: copilot-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
-          restore-keys: copilot-go-
+          path: ~/go/pkg/mod
+          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
+          restore-keys: |
+            copilot-go-build-
 
       - name: Download Go module dependencies
         run: |
@@ -45,3 +63,17 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,16 +37,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
@@ -63,17 +61,3 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
-
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}


### PR DESCRIPTION
## Summary
- split Go module and build caches in GitHub Actions workflows
- use exact module-cache keys and separate build-cache restore/save keys
- avoid carrying stale modules forward through restore-key based cache rollover
