### PR TITLE
Prefix workflow cache keys

### DIFF
--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -42,15 +42,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: build-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
+          key: build-go-build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            build-${{ matrix.go-version-alias }}-
+            build-go-build-${{ matrix.go-version-alias }}-
 
       - name: Build sample mod
         run: make examples/samplemod/build

--- a/.github/workflows/callable-test-function.yaml
+++ b/.github/workflows/callable-test-function.yaml
@@ -42,15 +42,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: function-test-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: function-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
+          key: function-test-go-build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            function-test-${{ matrix.go-version-alias }}-
+            function-test-go-build-${{ matrix.go-version-alias }}-
 
       - name: Run samplemod executable
         run: make examples/samplemod/run

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -42,15 +42,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: unit-test-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: unit-test-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
+          key: unit-test-go-build-${{ matrix.go-version-alias }}-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            unit-test-${{ matrix.go-version-alias }}-
+            unit-test-go-build-${{ matrix.go-version-alias }}-
 
       - name: Run tests
         run: make test/unit-json

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -64,9 +64,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
+          key: govulncheck-go-build-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            govulncheck-build-
+            govulncheck-go-build-
 
       - name: Run govulncheck
         run: make static-analysis/vulncheck-sarif


### PR DESCRIPTION
## Summary
- prefix each cache key with the job and cache purpose before the hash
- avoid immutable cache collisions across workflows that share dependency hashes
- keep the existing split module/build cache behavior