### PR TITLE
feat: standardize Makefile targets to directory-like naming convention

### DIFF
--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -53,7 +53,7 @@ jobs:
             unit-test-go-build-${{ matrix.go-version-alias }}-
 
       - name: Run tests
-        run: make test/unit-json
+        run: make test/unit/json
 
 
       - name: Publish test results
@@ -71,5 +71,5 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: go-coverage-report-${{ matrix.go-version-alias }}
+          name: go-coverage/report-${{ matrix.go-version-alias }}
           path: build/coverage.html

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -71,5 +71,5 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: go-coverage/report-${{ matrix.go-version-alias }}
+          name: go-coverage-report-${{ matrix.go-version-alias }}
           path: build/coverage.html

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -69,7 +69,7 @@ jobs:
             govulncheck-go-build-
 
       - name: Run govulncheck
-        run: make static-analysis/vulncheck-sarif
+        run: make static-analysis/vulncheck/sarif
 
 
       - name: Upload SARIF report

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -57,7 +57,7 @@ jobs:
           go mod download -modfile tools/go.mod
 
       - name: Install golangci-lint
-        run: make install/tools
+        run: make install/lint
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version

--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,5 @@ static-analysis/vulncheck-sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 
-install/tools:
+install/lint:
 	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ examples/samplemod/run: examples/samplemod/build
 		--sample.op.broken.disable true \
 		--sample.op.unstable.disable true
 
-examples/samplemod/run-longer: examples/samplemod/build
+examples/samplemod/run/longer: examples/samplemod/build
 	build/examples/samplemod \
 		cli \
 		--duration 120s \
@@ -28,7 +28,7 @@ examples/samplemod/run-longer: examples/samplemod/build
 		--sample.op.test.rate 120 \
 		--sample.op.broken.disable true \
 
-examples/samplemod/run-interactive: examples/samplemod/build
+examples/samplemod/run/interactive: examples/samplemod/build
 	build/examples/samplemod \
 		cli \
 		-i \
@@ -42,7 +42,7 @@ test/unit:
 	mkdir -p build
 	go test ./... -v -failfast -coverprofile=build/coverage.out
 
-test/unit-json:
+test/unit/json:
 	mkdir -p build
 	go test ./... -failfast -coverprofile=build/coverage.out -json > build/unit-test-output.json
 
@@ -52,7 +52,7 @@ static-analysis/lint:
 static-analysis/vulncheck:
 	go tool -modfile tools/go.mod govulncheck ./... || true
 
-static-analysis/vulncheck-sarif:
+static-analysis/vulncheck/sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/vulncheck.sarif
 


### PR DESCRIPTION
Renames `install/tools` → `install/lint` for consistency with the standard taxonomy. Updates `copilot-setup-steps.yml` accordingly.