### PR TITLE
refactor: remove unreachable empty InfoLogPath branch in setupLoggers

### DIFF
--- a/arbiter.go
+++ b/arbiter.go
@@ -373,21 +373,17 @@ func setupLoggers(opts *Opts, verbosity int) (logr.Logger, logr.Logger, error) {
 	}
 
 	var infoLogger logr.Logger
-	if opts.InfoLogPath == "" {
-		infoLogger = logr.Discard()
-	} else {
-		infoFile, err := os.Create(opts.InfoLogPath) //nolint:govet // shad
-		if err != nil {
-			return logr.Logger{}, logr.Logger{}, err
-		}
-
-		infoLogger = zerologr.New(&zerologr.Opts{
-			Output:  infoFile,
-			Console: true,
-			Caller:  true,
-			V:       verbosity,
-		}).WithName("abtr")
+	infoFile, err := os.Create(opts.InfoLogPath) //nolint:govet // shad
+	if err != nil {
+		return logr.Logger{}, logr.Logger{}, err
 	}
+
+	infoLogger = zerologr.New(&zerologr.Opts{
+		Output:  infoFile,
+		Console: true,
+		Caller:  true,
+		V:       verbosity,
+	}).WithName("abtr")
 
 	errorLogger := zerologr.New(&zerologr.Opts{
 		Output:  errorFile,

--- a/arbiter.go
+++ b/arbiter.go
@@ -373,7 +373,7 @@ func setupLoggers(opts *Opts, verbosity int) (logr.Logger, logr.Logger, error) {
 	}
 
 	var infoLogger logr.Logger
-	infoFile, err := os.Create(opts.InfoLogPath) //nolint:govet // shad
+	infoFile, err := os.Create(opts.InfoLogPath)
 	if err != nil {
 		return logr.Logger{}, logr.Logger{}, err
 	}


### PR DESCRIPTION
## Summary

`opts.InfoLogPath` is always populated by `defaultOpts()` before `setupLoggers()` is ever called in `Run()`, so the `logr.Discard()` fallback branch for an empty path could never be reached.

Removes the dead `if opts.InfoLogPath == ""{ ... }` block and simplifies `setupLoggers` to unconditionally open the info log file.