### PR TITLE
chore: sync dependabot-auto-approve with github-actions-help reference

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -43,13 +43,7 @@ jobs:
           fi
 
       - name: Re-approve after branch update if auto-merge was already configured
-        # Runs on synchronize events where step 4 would be skipped — i.e. when fetch-metadata
-        # either failed (outcome=failure) or returned an empty/unexpected update-type.
-        # The auto-merge check inside the script guards against re-approving major updates.
-        if: >-
-          github.event.action == 'synchronize' &&
-          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
-          steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        if: github.event.action == 'synchronize' && steps.metadata.outcome == 'failure'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Syncs the `dependabot-auto-approve.yaml` workflow to match the reference in `maansaake/github-actions-help`.

**Change:** The Re-approve step's `if` condition was using `!= semver-patch && != semver-minor` (with a comment block). This reverts it back to the simpler `steps.metadata.outcome == 'failure'` as specified in the reference.